### PR TITLE
Create fetch abort controller list and call in update

### DIFF
--- a/public/index.ejs
+++ b/public/index.ejs
@@ -347,7 +347,7 @@ function updateFollowingUI(users) {
 
 function abortPendingFetches() {
   // Abort all fetches since last UI update.
-  abortControllersList.map(item => {
+  abortControllersList.forEach(item => {
     // Each item in the list is an AbortController object.
     item.abort();
   });

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -122,8 +122,7 @@ const following = document.querySelector('ul#following');
 const input = document.querySelector('input#username');
 const output = document.querySelector('ul#output');
 
-// List of objects with URL being fetched as key, and its AbortController as
-// value.
+// Used to abort all outstanding fetches upon single-page navigation.
 const abortControllersList = [];
 
 function updateUIToMatchURL() {

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -122,6 +122,9 @@ const following = document.querySelector('ul#following');
 const input = document.querySelector('input#username');
 const output = document.querySelector('ul#output');
 
+// list of objects with URL being fetched as key, and its AbortController object as value
+const repoURLAbortControllersList = [];  
+
 function updateUIToMatchURL() {
   const username = new URL(location.href).searchParams.get('username');
   if (!username)
@@ -186,7 +189,16 @@ async function update() {
 
   while (nextLink) {
     console.log(`Fetching nextLink=${nextLink}`);
-    let response = await fetch(nextLink, {headers: kGitHubHeaders});
+
+    // create a new AbortController and add it the list
+    const controller = new AbortController();
+    repoURLAbortControllersList.push({nextLink: controller});
+
+    let options = {
+      headers: kGitHubHeaders,
+      signal: controller.signal
+    };
+    let response = await fetch(nextLink, options);
     let currentRepos = await response.json();
 
     fetchReposAndUpdate(currentRepos);
@@ -229,6 +241,10 @@ async function fetchReposAndUpdate(repositories) {
     const a = li.appendChild(document.createElement('a'));
     a.innerText = repository.name;
 
+    a.onclick = e => {
+      fetchAbortHandler();
+    }
+
     // This will redirect appropriately when custom domains are used.
     a.href = `https://${username}.github.io/${repository.name}`;
     a.target = '_blank';
@@ -267,9 +283,18 @@ function updateFollowingUI(users) {
       e.preventDefault();
       history.pushState({path: newURL.toString()}, '', newURL.toString());
       updateUIToMatchURL();
+      fetchAbortHandler();
       update();
     }
   }
+}
+
+function fetchAbortHandler() {
+  // abort all fetches in list
+  repoURLAbortControllersList.forEach((item) => {
+    let controller = item.values()[0];
+    controller.abort();
+  });
 }
 </script>
 </body>

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -122,8 +122,9 @@ const following = document.querySelector('ul#following');
 const input = document.querySelector('input#username');
 const output = document.querySelector('ul#output');
 
-// list of objects with URL being fetched as key, and its AbortController object as value
-const repoURLAbortControllersList = [];  
+// List of objects with URL being fetched as key, and its AbortController as
+// value.
+const abortControllersList = [];
 
 function updateUIToMatchURL() {
   const username = new URL(location.href).searchParams.get('username');
@@ -184,21 +185,40 @@ async function update() {
   if (username === '')
     return;
 
+  // Abort resources being fetched.
+  abortPendingFetches();
+
   // Get a list of all the user's repositories, and filter them based on whether they have deployments urls.
   let nextLink = `https://api.github.com/users/${username}/repos?per_page=50`;
 
   while (nextLink) {
     console.log(`Fetching nextLink=${nextLink}`);
 
-    // create a new AbortController and add it the list
     const controller = new AbortController();
-    repoURLAbortControllersList.push({nextLink: controller});
-
-    let options = {
+    abortControllersList.push(controller);
+    
+    const options = {
       headers: kGitHubHeaders,
       signal: controller.signal
     };
-    let response = await fetch(nextLink, options);
+
+    let response = null;
+
+    try {
+      response = await fetch(nextLink, options);
+    } catch(e) {
+      console.assert(e.name === 'AbortError');
+    }
+
+    if (response === null) {
+      // Note that we must return here instead of "continuing" to the next
+      // iteration because once we receive the signal that fetches are to be
+      // aborted, we should not generate any more as a part of the above while
+      // loop. The abort is intended to cancel all ongoing fetches as well as
+      // any future ones associated with the last single-page navigation.
+      return;
+    }
+
     let currentRepos = await response.json();
 
     fetchReposAndUpdate(currentRepos);
@@ -214,11 +234,31 @@ async function fetchReposAndUpdate(repositories) {
   const username = input.value;
 
   let deployments = repositories.map(repository => {
-    return fetch(repository.deployments_url, {headers: kGitHubHeaders})
+    const nextLink = repository.deployments_url;
+    const controller = new AbortController();
+    abortControllersList.push(controller);
+
+    const options = {
+      headers: kGitHubHeaders,
+      signal: controller.signal
+    };
+
+    return fetch(nextLink, options)
       .then(deployment => deployment.json());
   });
 
-  deployments = await Promise.all(deployments);
+  try {
+    deployments = await Promise.all(deployments);
+  } catch(e) {
+    console.assert(e.name === 'AbortError');
+    deployments = null;
+  }
+
+  // If the pending repository navigations are aborted, immediately return so
+  // that we don't try to do anything with the DOM etc.
+  if (deployments === null) {
+    return;
+  }
 
   repositories.forEach((repository, i) => {
     repository.deployments = deployments[i];
@@ -241,10 +281,6 @@ async function fetchReposAndUpdate(repositories) {
     const a = li.appendChild(document.createElement('a'));
     a.innerText = repository.name;
 
-    a.onclick = e => {
-      fetchAbortHandler();
-    }
-
     // This will redirect appropriately when custom domains are used.
     a.href = `https://${username}.github.io/${repository.name}`;
     a.target = '_blank';
@@ -260,7 +296,28 @@ async function populateFollowers() {
 
   while (nextLink) {
     console.log(`Fetching nextLink=${nextLink}`);
-    let response = await fetch(nextLink, {headers: kGitHubHeaders});
+
+    const controller = new AbortController();
+    abortControllersList.push(controller);
+
+    const options = {
+      headers: kGitHubHeaders,
+      signal: controller.signal
+    };
+
+    let response = null;
+    
+    try {
+      response = await fetch(nextLink, options);
+    } catch(e) {
+      console.assert(e.name === 'AbortError');
+    }
+
+    if (response === null) {
+      // See the corresponding block in `update()` for documentation.
+      return;
+    }
+
     let users = await response.json();
 
     updateFollowingUI(users);
@@ -283,18 +340,20 @@ function updateFollowingUI(users) {
       e.preventDefault();
       history.pushState({path: newURL.toString()}, '', newURL.toString());
       updateUIToMatchURL();
-      fetchAbortHandler();
       update();
     }
   }
 }
 
-function fetchAbortHandler() {
-  // abort all fetches in list
-  repoURLAbortControllersList.forEach((item) => {
-    let controller = item.values()[0];
-    controller.abort();
+function abortPendingFetches() {
+  // Abort all fetches since last UI update.
+  abortControllersList.map(item => {
+    // Each item in the list is an AbortController object.
+    item.abort();
   });
+
+  // Deletes all AbortControllers from the list.
+  abortControllersList.length = 0;
 }
 </script>
 </body>


### PR DESCRIPTION
This PR creates an `AbortController` object when a `fetch` is issued for a new URL.  ~~The `AbortController` is stored in a list which is indexed by its URL.~~  The `abortPendingFetches` function iterates through the list and for each controller calls `abort()` for the `fetch`, and then clears the list.  `abortPendingFetches` is called as a part of the `update` function.

Making some assumptions on behavior, that everything being fetched in the list should be cancelled, and that its ok for the list to persist at a global scope.

https://github.com/domfarolino/pages/issues/3